### PR TITLE
Use #![feature(tool_attributes)] and #[rustfmt::skip].

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(trace_macros)]
+#![feature(tool_attributes)]
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -119,7 +119,6 @@ enum MacroSession {
     EmptyLine,
 }
 
-#[cfg_attr(rustfmt, rustfmt_skip)] 
 fn macro_line<'a>(input: CompleteStr<'a>, t: &str) -> IResult<CompleteStr<'a>, Identifier> {
     do_parse!(
         input,        
@@ -359,7 +358,7 @@ named!(
     )
 );
 
-#[cfg_attr(rustfmt, rustfmt_skip)] 
+#[rustfmt::skip]
 named!(
     ifcond_macro<CS, MacroSession>, 
     do_parse!(            
@@ -467,7 +466,7 @@ named!(
     )
 );
 
-#[rustfmt_skip] 
+#[rustfmt::skip]
 named!(
     #[allow(unused_imports)],  // fix value! warning
     preprocess_parser <CS,Vec<MacroSession>>,


### PR DESCRIPTION
Fixes compilation error on nightly rust by skipping rustfmt with the newer method detailed [here](https://github.com/rust-lang-nursery/rustfmt).

The error:
```
error[E0658]: The attribute `rustfmt_skip` is currently unknown to the compiler and may have meaning added to it in the
future (see issue #29642)
   --> C:\Users\Kevin\.cargo\git\checkouts\uni-glsl-290da6b884e28c33\a418f73\src\preprocessor.rs:470:1
    |
470 | #[rustfmt_skip]
    | ^^^^^^^^^^^^^^^
    |
    = help: add #![feature(custom_attribute)] to the crate attributes to enable

```