### PR TITLE
add nom::ErrorKind

### DIFF
--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -1,5 +1,5 @@
 use nom::types::CompleteStr;
-use nom::{space, Err, IResult};
+use nom::{space, Err, ErrorKind, IResult};
 use nom::line_ending;
 use std::convert::From;
 use std::collections::HashMap;


### PR DESCRIPTION
Fixes compilation errors.

```
error[E0433]: failed to resolve. Use of undeclared type or module `ErrorKind`
   --> src/preprocessor.rs:409:28
    |
409 |         spe!(return_error!(ErrorKind::Custom(1), char!('#'))) >>
    |                            ^^^^^^^^^ Use of undeclared type or module `ErrorKind`

```